### PR TITLE
Fixed spelling errors.

### DIFF
--- a/run-node-sepolia.md
+++ b/run-node-sepolia.md
@@ -30,7 +30,7 @@ git clone https://github.com/mantlenetworkio/networks.git
 
 ### 2 Generate init file
 
-generat the 'jwt\_secret\_txt' file and the 'p2p\_node\_key\_txt'
+generate the 'jwt\_secret\_txt' file and the 'p2p\_node\_key\_txt'
 
 ```
 cd networks/

--- a/run-node-testnet.md
+++ b/run-node-testnet.md
@@ -67,7 +67,7 @@ chaindata
 docker-compose -f docker-compose-testnet.yml up -d 
 ```
 
-Will start the node in a detatched shell (`-d`), meaning the node will continue to run in the background.
+Will start the node in a detached shell (`-d`), meaning the node will continue to run in the background.
 You will need to run this again if you ever turn your machine off.
 
 The first time you start the node it synchronizes from regenesis (December 1th, 2022) to the present.


### PR DESCRIPTION
Fixed typos:

generat → generate
detatched → detached
Why it's useful:
These corrections fix spelling errors, ensuring clarity and professionalism.