### PR TITLE
Fix typo run-node-mainnetv2.md

### DIFF
--- a/run-node-mainnetv2.md
+++ b/run-node-mainnetv2.md
@@ -87,7 +87,7 @@ chaindata
 docker-compose -f docker-compose-mainnetv2.yml up -d
 ```
 
-Will start the node in a detatched shell (`-d`), meaning the node will continue to run in the background.
+Will start the node in a detached shell (`-d`), meaning the node will continue to run in the background.
 You will need to run this again if you ever turn your machine off.
 
 The first time you start the node it synchronizes from regenesis (December 1th, 2022) to the present.


### PR DESCRIPTION
### Pull Request Title  
Fix Typo in run-node-mainnetv2.md  

---

### Description  
This pull request fixes a typo in the `run-node-mainnetv2.md` file.  

- **Original:** `detatched`  
- **Corrected:** `detached`  

The typo was found in the section describing the process or configuration for running a node on the mainnet.  

---

### Checklist  
- [x] Corrected the typo.  
- [ ] Reviewed the file for additional typos or inconsistencies.  
- [ ] Verified adherence to the project's code of conduct and contribution guidelines.  

---

Feel free to suggest additional improvements if needed! 🚀  
