### PR TITLE
run-node-mainnetv2.md

### DIFF
--- a/run-node-mainnetv2.md
+++ b/run-node-mainnetv2.md
@@ -87,7 +87,7 @@ chaindata
 docker-compose -f docker-compose-mainnetv2.yml up -d
 ```
 
-Will start the node in a detatched shell (`-d`), meaning the node will continue to run in the background.
+Will start the node in a detached shell (`-d`), meaning the node will continue to run in the background.
 You will need to run this again if you ever turn your machine off.
 
 The first time you start the node it synchronizes from regenesis (December 1th, 2022) to the present.


### PR DESCRIPTION
### Summary
Fixed a typo in `run-node-mainnetv2.md`.

### Changes
- Corrected "detatched" to "detached" for clarity and accuracy.

### Notes
- This is a minor documentation fix and does not affect the codebase or functionality.
