### PR TITLE
upgrade mainnet to v1.5.4: remove EigenDA, use healthcheck and L1 beacon

### DIFF
--- a/docker-compose-mainnetv2-upgrade-beacon.yml
+++ b/docker-compose-mainnetv2-upgrade-beacon.yml
@@ -5,7 +5,7 @@ x-healthcheck: &healthcheck
   interval: 5s
   timeout: 5s
   retries: 3
-  start_period: 30s
+  start_period: 60s
 
 services:
   op-geth:

--- a/docker-compose-mainnetv2-upgrade-beacon.yml
+++ b/docker-compose-mainnetv2-upgrade-beacon.yml
@@ -1,7 +1,7 @@
 version: '3.4'
 
 x-healthcheck: &healthcheck
-  test: [ "CMD", "curl", "-sf", "http://localhost:8545" ]
+  test: [ "CMD", "nc", "-zv", "-w", "2", "localhost", "8545" ]
   interval: 5s
   timeout: 5s
   retries: 3
@@ -9,7 +9,7 @@ x-healthcheck: &healthcheck
 
 services:
   op-geth:
-    image: mantlenetworkio/mantle-op-geth:v1.4.2
+    image: mantlenetworkio/mantle-op-geth:v1.5.4
     deploy:
       resources:
         limits:
@@ -61,8 +61,10 @@ services:
       - ${VERIFIER_HTTP_PORT:-8545}:8545
       - ${VERIFIER_WS_PORT:-8546}:8546
       - ${VERIFIER_AUTH_PORT:-8551}:8551
+    healthcheck:
+      <<: *healthcheck
   op-node:
-    image: mantlenetworkio/mantle-op-node:v1.4.2
+    image: mantlenetworkio/mantle-op-node:v1.5.4
     deploy:
       resources:
         limits:
@@ -74,8 +76,8 @@ services:
       restart_policy:
         condition: on-failure
     depends_on:
-      - op-geth
-      - eigenda-proxy
+      op-geth:
+        condition: service_healthy
     volumes:
       - ./mainnet/secret:/secret
       - ./mainnet/rollup.json:/config/rollup.json
@@ -101,46 +103,11 @@ services:
       OP_NODE_PPROF_ADDR: '0.0.0.0'
       OP_NODE_P2P_DISCOVERY_PATH: '/op-node/opnode_discovery_db'
       OP_NODE_P2P_PEERSTORE_PATH: '/op-node/opnode_peerstore_db'
-      OP_NODE_INDEXER_SOCKET: 'da-indexer-api.mantle.xyz:443'
-      OP_NODE_INDEXER_ENABLE: 'false'
       OP_NODE_L2_BACKUP_UNSAFE_SYNC_RPC: https://rpc.mantle.xyz
       OP_NODE_P2P_STATIC: '/dns4/peer0.mantle.xyz/tcp/9003/p2p/16Uiu2HAmKVKzUAns2gLhZAz1PYcbnhY3WpxNxUZYeTN1x29tNBAW,/dns4/peer1.mantle.xyz/tcp/9003/p2p/16Uiu2HAm1AiZtVp8f5C8LvpSTAXC6GtwqAVKnB3VLawWYSEBmcFN,/dns4/peer2.mantle.xyz/tcp/9003/p2p/16Uiu2HAm2UHVKiPXpovs8VbbUQVPr7feBAqBJdFsH1z5XDiLEvHT'
       OP_NODE_SEQUENCER_ENABLED: 'false'
       OP_NODE_P2P_AGENT: 'mantle'
-      OP_NODE_L2_ENGINE_SYNC_ENABLED: 'true'
-      OP_NODE_L2_SKIP_SYNC_START_CHECK: 'true'
       OP_NODE_P2P_SYNC_REQ_RESP: 'true'
       OP_NODE_L1_BEACON: $L1_BEACON_MAINNET
-      OP_NODE_RETRIEVER_TIMEOUT: 120s
-      OP_NODE_EIGENDA_PROXY_URL: 'http://eigenda-proxy:3100'
-      OP_NODE_EIGENDA_DISPERSER_URL: 'disperser.eigenda.xyz:443'
-
     ports:
       - ${NODE_RPC_PORT:-9545}:8545
-  eigenda-proxy:
-    image: mantlenetworkio/eigenda-proxy:v1.6.3
-    pull_policy: always
-    deploy:
-      resources:
-        limits:
-          cpus: '1'
-          memory: 2000M
-        reservations:
-          cpus: '1'
-          memory: 2000M
-      restart_policy:
-        condition: on-failure
-    environment:
-      EIGENDA_PROXY_ADDR: "0.0.0.0"
-      EIGENDA_PROXY_PORT: "3100"
-      EIGENDA_PROXY_EIGENDA_DISPERSER_RPC: "disperser.eigenda.xyz:443"
-      EIGENDA_PROXY_EIGENDA_ETH_RPC: $L1_RPC_MAINNET
-      EIGENDA_PROXY_EIGENDA_ETH_CONFIRMATION_DEPTH: "6"
-      EIGENDA_PROXY_EIGENDA_SERVICE_MANAGER_ADDR: "0x870679e138bcdf293b7ff14dd44b70fc97e12fc0"
-      EIGENDA_PROXY_EIGENDA_MAX_BLOB_LENGTH: "4MiB"
-      EIGENDA_PROXY_METRICS_ENABLED: "true"
-      EIGENDA_PROXY_METRICS_PORT: "7300"
-      EIGENDA_PROXY_EIGENDA_STATUS_QUERY_TIMEOUT: "20m0s"
-      EIGENDA_PROXY_EIGENDA_CERT_VERIFICATION_DISABLED: "true"
-    ports:
-      - 3100:3100

--- a/docker-compose-mainnetv2-upgrade-da-indexer.yml
+++ b/docker-compose-mainnetv2-upgrade-da-indexer.yml
@@ -5,7 +5,7 @@ x-healthcheck: &healthcheck
   interval: 5s
   timeout: 5s
   retries: 3
-  start_period: 30s
+  start_period: 60s
 
 services:
   op-geth:

--- a/docker-compose-mainnetv2-upgrade-da-indexer.yml
+++ b/docker-compose-mainnetv2-upgrade-da-indexer.yml
@@ -1,7 +1,7 @@
 version: '3.4'
 
 x-healthcheck: &healthcheck
-  test: [ "CMD", "curl", "-sf", "http://localhost:8545" ]
+  test: [ "CMD", "nc", "-zv", "-w", "2", "localhost", "8545" ]
   interval: 5s
   timeout: 5s
   retries: 3
@@ -9,7 +9,7 @@ x-healthcheck: &healthcheck
 
 services:
   op-geth:
-    image: mantlenetworkio/mantle-op-geth:v1.4.2
+    image: mantlenetworkio/mantle-op-geth:v1.5.4
     deploy:
       resources:
         limits:
@@ -61,8 +61,10 @@ services:
       - ${VERIFIER_HTTP_PORT:-8545}:8545
       - ${VERIFIER_WS_PORT:-8546}:8546
       - ${VERIFIER_AUTH_PORT:-8551}:8551
+    healthcheck:
+      <<: *healthcheck
   op-node:
-    image: mantlenetworkio/mantle-op-node:v1.4.2
+    image: mantlenetworkio/mantle-op-node:v1.5.4
     deploy:
       resources:
         limits:
@@ -74,7 +76,8 @@ services:
       restart_policy:
         condition: on-failure
     depends_on:
-      - op-geth
+      op-geth:
+        condition: service_healthy
     volumes:
       - ./mainnet/secret:/secret
       - ./mainnet/rollup.json:/config/rollup.json
@@ -100,14 +103,11 @@ services:
       OP_NODE_PPROF_ADDR: '0.0.0.0'
       OP_NODE_P2P_DISCOVERY_PATH: '/op-node/opnode_discovery_db'
       OP_NODE_P2P_PEERSTORE_PATH: '/op-node/opnode_peerstore_db'
-      OP_NODE_INDEXER_SOCKET: 'da-indexer-api.mantle.xyz:443'
-      OP_NODE_INDEXER_ENABLE: 'true'
       OP_NODE_L2_BACKUP_UNSAFE_SYNC_RPC: https://rpc.mantle.xyz
       OP_NODE_P2P_STATIC: '/dns4/peer0.mantle.xyz/tcp/9003/p2p/16Uiu2HAmKVKzUAns2gLhZAz1PYcbnhY3WpxNxUZYeTN1x29tNBAW,/dns4/peer1.mantle.xyz/tcp/9003/p2p/16Uiu2HAm1AiZtVp8f5C8LvpSTAXC6GtwqAVKnB3VLawWYSEBmcFN,/dns4/peer2.mantle.xyz/tcp/9003/p2p/16Uiu2HAm2UHVKiPXpovs8VbbUQVPr7feBAqBJdFsH1z5XDiLEvHT'
       OP_NODE_SEQUENCER_ENABLED: 'false'
       OP_NODE_P2P_AGENT: 'mantle'
-      OP_NODE_L2_ENGINE_SYNC_ENABLED: 'true'
-      OP_NODE_L2_SKIP_SYNC_START_CHECK: 'true'
       OP_NODE_P2P_SYNC_REQ_RESP: 'true'
+      OP_NODE_L1_BEACON: 'https://da-indexer-api.mantle.xyz'
     ports:
       - ${NODE_RPC_PORT:-9545}:8545

--- a/docker-compose-sepolia-upgrade-beacon.yml
+++ b/docker-compose-sepolia-upgrade-beacon.yml
@@ -5,7 +5,7 @@ x-healthcheck: &healthcheck
   interval: 5s
   timeout: 5s
   retries: 3
-  start_period: 30s
+  start_period: 60s
 
 services:
   op-geth:

--- a/docker-compose-sepolia-upgrade-da-indexer.yml
+++ b/docker-compose-sepolia-upgrade-da-indexer.yml
@@ -5,7 +5,7 @@ x-healthcheck: &healthcheck
   interval: 5s
   timeout: 5s
   retries: 3
-  start_period: 30s
+  start_period: 60s
 
 services:
   op-geth:

--- a/mainnet/rollup.json
+++ b/mainnet/rollup.json
@@ -26,7 +26,5 @@
   "regolith_time": 0,
   "batch_inbox_address": "0xFFEEDDCcBbAA0000000000000000000000000000",
   "deposit_contract_address": "0xc54cb22944f2be476e02decfcd7e3e7d3e15a8fb",
-  "l1_system_config_address": "0x427ea0710fa5252057f0d88274f7aeb308386caf",
-  "mantle_da_switch": true,
-  "datalayr_service_manager_addr": "0x5BD63a7ECc13b955C4F57e3F12A64c10263C14c1"
+  "l1_system_config_address": "0x427ea0710fa5252057f0d88274f7aeb308386caf"
 }

--- a/run-node-mainnetv2.md
+++ b/run-node-mainnetv2.md
@@ -103,6 +103,23 @@ wget https://s3.ap-southeast-1.amazonaws.com/snapshot.mantle.xyz/historyrpcdata-
 tar --use-compress-program=unzstd -xvf historyrpcdata-mainnet-chaindata.tar.zst -C ./data/gethv1
 docker-compose -f docker-compose-mainnetv1.yml up -d
 ``` 
+
+#### Start with L1 beacon chain（recommend）
+
+use L1 beacon chain to pull the data for rollup node, 
+
+you need to edit L1_BEACON_MAINNET and L1_RPC_MAINNET
+
+L1_BEACON_MAINNET is for querying data from eth blob
+
+then start with
+
+```
+export L1_RPC_MAINNET='https://rpc.ankr.com/eth'  #please replace
+export L1_BEACON_MAINNET='https://eth-beacon-chain.drpc.org/rest/'  #please replace
+docker-compose -f docker-compose-mainnetv2-upgrade-beacon.yml up -d 
+```
+
 #### Stop
 
 ```sh
@@ -136,7 +153,11 @@ The available services are:
 - [`op-geth`](#mantle-node)
 - [`op-node`](#mantle-node)
 
-#### Upgrade for historical user
+
+# Upgrade for historical user
+> **Note:** When upgrading, please follow the correct update order: update **mantle-op-geth** first, then update **mantle-op-node**. Reversing this order may cause unexpected issues.
+> 
+> ⚠️ **Important for v1.5.4 Upgrade:** When updating to v1.5.4 version, you must ensure that mantle-op-geth starts before mantle-op-node. Failure to follow this order may cause chain fork. If a fork occurs, please rebuild the RPC node by following the full setup instructions in this document.
 
 ## 1 Stop historical node
 
@@ -174,13 +195,14 @@ tar --use-compress-program=unzstd -xvf historyrpcdata-mainnet-chaindata.tar.zst 
 docker-compose -f docker-compose-mainnetv1.yml up -d
 ``` 
 
-### 3.2 start with EigenDA and L1 beacon chain （recommend）
+### 3.2 start with L1 beacon chain（recommend）
 
-use EigenDA and L1 beacon chain to pull the data for rollup node, 
+use L1 beacon chain to pull the data for rollup node
 
 you need to edit L1_BEACON_MAINNET and L1_RPC_MAINNET
 
-L1_BEACON_MAINNET is for querying data from eth blob if eigenda failed 
+L1_BEACON_MAINNET is for querying data from eth blob
+
 
 then start with
 


### PR DESCRIPTION
- Upgrade op-geth and op-node images to v1.5.4
- Replace curl healthcheck with nc for reliability
- Add healthcheck to op-geth, use service_healthy depends_on to ensure correct startup order
- Remove EigenDA proxy service and related env vars from beacon compose
- Remove DA indexer env vars, use L1_BEACON instead
- Remove mantle_da_switch and datalayr_service_manager_addr from rollup.json
- Update docs: remove EigenDA references, add v1.5.4 upgrade warning